### PR TITLE
Split content into dedicated pages

### DIFF
--- a/_includes/header.md
+++ b/_includes/header.md
@@ -1,4 +1,4 @@
-<link rel="canonical" href="https://consciousness-is-unambiguous.com/">
+<link rel="canonical" href="{{ page.url | absolute_url }}">
 
 
 <script id="MathJax-script" async src="https://cdn.jsdelivr.net/npm/mathjax@3/es5/tex-mml-chtml.js"></script>
@@ -10,7 +10,7 @@
   "@type": "ScholarlyArticle",
   "mainEntityOfPage": {
     "@type": "WebPage",
-    "@id": "https://consciousness-is-unambiguous.com/"
+    "@id": "{{ page.url | absolute_url }}"
   },
   "headline": "Consciousness and Unambiguous Representations",
   "image": "https://consciousness-is-unambiguous.com/assets/images/background.png",
@@ -29,7 +29,7 @@
   },
   "datePublished": "2025-04-15",
   "dateModified": "2025-08-06",
-  "url": "https://consciousness-is-unambiguous.com/",
+  "url": "{{ page.url | absolute_url }}",
   "description": "This article investigates the intentionality constraint on neural correlates of consciousness and how unambiguous representations emerge in neural networks.",
   "keywords": "consciousness, neural networks, ambiguity, representationalism, representations, entropy, intentionality, philosophy of mind",
   "inLanguage": "en"

--- a/ambiguity-analysis.md
+++ b/ambiguity-analysis.md
@@ -1,0 +1,8 @@
+---
+layout: default
+title: Ambiguity Analysis
+---
+
+{% include header.md %}
+{% include ambiguity-analysis.md %}
+

--- a/exhibit1.md
+++ b/exhibit1.md
@@ -1,0 +1,8 @@
+---
+layout: default
+title: Exhibit 1
+---
+
+{% include header.md %}
+{% include exhibit1.md %}
+

--- a/exhibit2.md
+++ b/exhibit2.md
@@ -1,0 +1,8 @@
+---
+layout: default
+title: Exhibit 2
+---
+
+{% include header.md %}
+{% include exhibit2.md %}
+

--- a/index.md
+++ b/index.md
@@ -1,15 +1,18 @@
-{% include header.md %}
-
-{% include theory.md %}
-
+---
+layout: default
+title: Consciousness and Unambiguous Representations
 ---
 
-{% include exhibit1.md %}
+{% include header.md %}
 
-{% include exhibit2.md %}
+Welcome to the Consciousness and Unambiguous Representations project. Choose a section to explore:
 
-{% include ambiguity-analysis.md %}
+## Sections
 
-{% include related-work.md %}
+- [Theory]({{ '/theory/' | relative_url }})
+- [Exhibit 1]({{ '/exhibit1/' | relative_url }})
+- [Exhibit 2]({{ '/exhibit2/' | relative_url }})
+- [Ambiguity Analysis]({{ '/ambiguity-analysis/' | relative_url }})
+- [Related Work]({{ '/related-work/' | relative_url }})
+- [References]({{ '/references/' | relative_url }})
 
-{% include references.md %}

--- a/references.md
+++ b/references.md
@@ -1,0 +1,8 @@
+---
+layout: default
+title: References
+---
+
+{% include header.md %}
+{% include references.md %}
+

--- a/related-work.md
+++ b/related-work.md
@@ -1,0 +1,8 @@
+---
+layout: default
+title: Related Work
+---
+
+{% include header.md %}
+{% include related-work.md %}
+

--- a/theory.md
+++ b/theory.md
@@ -1,0 +1,8 @@
+---
+layout: default
+title: Theory
+---
+
+{% include header.md %}
+{% include theory.md %}
+


### PR DESCRIPTION
## Summary
- Add standalone pages for theory, exhibits, ambiguity analysis, related work, and references.
- Update index to link to new sections instead of embedding all content.
- Make canonical URLs dynamic in shared header for better SEO across pages.

## Testing
- `bundle exec jekyll build` *(fails: Could not locate Gemfile or .bundle/ directory)*
- `jekyll build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a328103690832ca7cc28ea66567458